### PR TITLE
Fix bool usage and cleanup error string

### DIFF
--- a/src/xpf.c
+++ b/src/xpf.c
@@ -606,12 +606,17 @@ void xpf_stop(void)
 	if (gXPF.osVersion) free(gXPF.osVersion);
 	if (gXPF.kernelInfoPlist) free(gXPF.kernelInfoPlist);
 
-	XPFItem *item = gXPF.firstItem;
-	while (item) {
-		XPFItem *curItem = item;
-		item = item->nextItem;
-		free(curItem);
-	}
-	
-	gXPF = (struct s_XPF){ 0 };
+        XPFItem *item = gXPF.firstItem;
+        while (item) {
+                XPFItem *curItem = item;
+                item = item->nextItem;
+                free(curItem);
+        }
+
+        if (gXPFError) {
+                free(gXPFError);
+                gXPFError = NULL;
+        }
+
+        gXPF = (struct s_XPF){ 0 };
 }

--- a/src/xpf.h
+++ b/src/xpf.h
@@ -1,4 +1,5 @@
 #include <stdint.h>
+#include <stdbool.h>
 
 #include <choma/Fat.h>
 #include <choma/Util.h>


### PR DESCRIPTION
## Summary
- include `<stdbool.h>` so the `bool` type and constants are defined
- free error string during `xpf_stop` to avoid memory leak

## Testing
- `make` *(fails: No rule to make target 'external/ChOma/src/*.c')*

------
https://chatgpt.com/codex/tasks/task_e_687920aafd088328a622c04a1a26214a